### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ While the `id` attribute might be fine in HTML and JavaScript, it should be **av
 ##### Bad
 
 ```css
-#ur-name {
+# ur-name {
   // ...
 }
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
